### PR TITLE
Modernize UnoCSS integration for SvelteKit 2 and Svelte 5

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,3 @@
+@import '@unocss/reset/tailwind.css';
+
+/* Your custom styles here */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import 'virtual:uno.css';
+	import '../app.css';
 	import Theme from '$lib/theme/Theme.svelte';
 	import SidebarLayout from '$lib/layout/SidebarLayout/SidebarLayout.svelte';
 	import Logo from '$lib/Logo.svelte';

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -11,14 +11,17 @@ import extractorSvelte from '@unocss/extractor-svelte';
 
 export default defineConfig({
 	presets: [
+		presetUno({
+			dark: 'class'
+		}),
 		presetAttributify({
 			prefix: 'un-'
 		}),
-		presetIcons(),
-		presetTypography(),
-		presetUno({
-			dark: 'class'
-		})
+		presetIcons({
+			scale: 1.2,
+			warn: true
+		}),
+		presetTypography()
 	],
 	extractors: [extractorSvelte()],
 	transformers: [transformerDirectives(), transformerVariantGroup()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,10 @@
 import type { UserConfig } from 'vite';
-import unocss from 'unocss/vite';
+import UnoCSS from 'unocss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 
 const config: UserConfig = {
 	plugins: [
-		unocss({
-			configFile: 'unocss.config.ts'
-		}),
+		UnoCSS(),
 		sveltekit()
 	],
 	// test: {


### PR DESCRIPTION
## Summary
- Update UnoCSS from v0.61.3 to v66.1.4 for full Svelte 5 compatibility
- Optimize configuration with proper preset ordering and enhanced settings
- Add CSS reset integration for consistent base styles across components

## Test plan
- [ ] Verify all components render correctly with updated UnoCSS
- [ ] Check that dark mode toggle still works properly
- [ ] Confirm icon presets function with enhanced settings
- [ ] Test build process completes without errors
- [ ] Validate that custom theme colors remain functional

🤖 Generated with [Claude Code](https://claude.ai/code)